### PR TITLE
Set Content-Type to JSON

### DIFF
--- a/main.go
+++ b/main.go
@@ -41,6 +41,7 @@ func (a *App) ListHandler(w http.ResponseWriter, r *http.Request) {
 	starsJSON, _ := json.Marshal(stars)
 
 	// Write to HTTP response.
+	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
 	w.Write([]byte(starsJSON))
 }
@@ -54,6 +55,7 @@ func (a *App) ViewHandler(w http.ResponseWriter, r *http.Request) {
 	starJSON, _ := json.Marshal(star)
 
 	// Write to HTTP response.
+	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
 	w.Write([]byte(starJSON))
 }


### PR DESCRIPTION
Would it be beneficial to set the Content-Type header for the HTTP response in the ListHandler and ViewHandler to mirror an API instead of the default plain/text?